### PR TITLE
Added HT16K33

### DIFF
--- a/package-list.yaml
+++ b/package-list.yaml
@@ -149,3 +149,10 @@ packages:
     description: Device drivers for IR (infra red) remote controls
     license: MIT license
     tags: ["IR"]
+  - HT16K33-Python:
+    name: HT16K33 Drivers
+    url: https://github.com/smittytone/HT16K33-Python
+    description: Python drivers for the Holtek HT16K33 controller chip and various display devices based upon it, such as the Adafruit 0.8-inch 8x16 LED Matrix FeatherWing and the Raspberry Pi Pico.
+The drivers supports both CircuitPython and MicroPython applications. They communicate using I²C.
+    tags: ["LED", "matrix", "segment", "adafruit"]
+    license: Licensed under the MIT License.


### PR DESCRIPTION
This driver supports a number of devices based on Holtek HT16K33, including Adafruit LED backpacks for Segment and Matrix displays